### PR TITLE
Switch network, hide evm address if account not binded yet

### DIFF
--- a/packages/extension-ui/src/Popup/Accounts/Account.tsx
+++ b/packages/extension-ui/src/Popup/Accounts/Account.tsx
@@ -91,7 +91,7 @@ function Account ({ address, className, genesisHash, isExternal, isHardware, isH
       >
         {t<string>('Forget Account')}
       </Link>
-      {!isHardware && (
+      {!isHardware && !!genesisOptions.length && (
         <>
           <MenuDivider />
           <div className='menuItem'>

--- a/packages/extension-ui/src/components/Address.tsx
+++ b/packages/extension-ui/src/components/Address.tsx
@@ -377,7 +377,7 @@ function Address ({ actions, address, children, className, exporting, genesisHas
           </div>
 
           {
-            signer?.evmAddress
+            signer?.evmAddress && signer?.isEvmClaimed
               ? <>
                 <div className='account-card__meta'>
                   <div

--- a/packages/extension-ui/src/hooks/useGenesisHashOptions.ts
+++ b/packages/extension-ui/src/hooks/useGenesisHashOptions.ts
@@ -27,10 +27,6 @@ export default function (): Option[] {
   }, []);
 
   const hashes = useMemo(() => [
-    {
-      text: t('Allow use on any chain'),
-      value: ''
-    },
     // put the relay chains at the top
     ...chains.filter(({ chain }) => chain.includes(RELAY_CHAIN))
       .map(({ chain, genesisHash }) => ({

--- a/packages/extension-ui/src/partials/MenuSettings.tsx
+++ b/packages/extension-ui/src/partials/MenuSettings.tsx
@@ -14,6 +14,7 @@ import useIsPopup from '../hooks/useIsPopup';
 import useTranslation from '../hooks/useTranslation';
 import { setNotification, windowOpen } from '../messaging';
 import getLanguageOptions from '../util/getLanguageOptions';
+import { availableNetworks, Network, appState } from '@reef-defi/react-lib';
 
 interface Props extends ThemeProps {
   className?: string;
@@ -23,11 +24,15 @@ interface Props extends ThemeProps {
 const notificationOptions = ['Extension', 'PopUp', 'Window']
   .map((item) => ({ text: item, value: item.toLowerCase() }));
 
+const networkOptions = [availableNetworks.mainnet, availableNetworks.testnet]
+  .map(network => ({text: network.name, value: network.rpcUrl}));
+
 function MenuSettings ({ className, reference }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const [camera, setCamera] = useState(settings.camera === 'on');
   // const [prefix, setPrefix] = useState(`${settings.prefix === -1 ? 42 : settings.prefix}`);
   const [notification, updateNotification] = useState(settings.notification);
+  const [network, setNetwork] = useState(settings.apiUrl);
   const themeContext = useContext(ThemeContext as React.Context<Theme>);
   const setTheme = useContext(ThemeSwitchContext);
   const isPopup = useIsPopup();
@@ -79,6 +84,17 @@ function MenuSettings ({ className, reference }: Props): React.ReactElement<Prop
     }, [onAction]
   );
 
+  const _onNetworkChange = useCallback(
+    (value: string) => {
+      const selectedNetwork: Network | undefined = Object.values(availableNetworks)
+        .find((network: Network) => network.rpcUrl === value);
+      if (selectedNetwork) {
+        appState.setCurrentNetwork(selectedNetwork);
+        setNetwork(selectedNetwork.rpcUrl);
+      }
+    }, []
+  );
+
   return (
     <Menu
       className={className}
@@ -117,6 +133,18 @@ function MenuSettings ({ className, reference }: Props): React.ReactElement<Prop
           onChange={_onChangeNotification}
           options={notificationOptions}
           value={notification}
+        />
+      </MenuItem>
+      <MenuItem
+        className='setting'
+        title={t<string>('Network')}
+      >
+        <Dropdown
+          className='dropdown'
+          label=''
+          onChange={_onNetworkChange}
+          options={networkOptions}
+          value={network}
         />
       </MenuItem>
       <MenuItem


### PR DESCRIPTION
[fix: hide evm address for account if not binded yet](https://github.com/reef-defi/browser-extension/commit/ac87c7fad26c9bae9e71666ec2e3a2586a47cc25)
[fix: removed Allow use on any chain dropdown input](https://github.com/reef-defi/browser-extension/commit/e916c49055b89ee76b01f1b34b2a5fcda856afea)
[feat: switch network in settings popup](https://github.com/reef-defi/browser-extension/commit/a8445e1d2447dc074fcc30c4fe87807a904fd06c)