### PR TITLE
web3Enable - wait until extension is registered

### DIFF
--- a/packages/extension-dapp/src/index.ts
+++ b/packages/extension-dapp/src/index.ts
@@ -62,8 +62,8 @@ function getWindowExtensions (originName: string): Promise<[InjectedExtensionInf
   );
 }
 
-const onReefInjectedPromise:()=>Promise<boolean> = ()=>new Promise(resolve => {
-  document.addEventListener('reef-injected', ()=>resolve(true), false);
+const onReefInjectedPromise: () => Promise<boolean> = () => new Promise((resolve) => {
+  document.addEventListener('reef-injected', () => resolve(true), false);
 });
 
 // enables all the providers found on the injected window interface

--- a/packages/extension-dapp/src/index.ts
+++ b/packages/extension-dapp/src/index.ts
@@ -62,11 +62,17 @@ function getWindowExtensions (originName: string): Promise<[InjectedExtensionInf
   );
 }
 
+const onReefInjectedPromise:()=>Promise<boolean> = ()=>new Promise(resolve => {
+  document.addEventListener('reef-injected', ()=>resolve(true), false);
+});
+
 // enables all the providers found on the injected window interface
 export function web3Enable (originName: string, compatInits: (() => Promise<boolean>)[] = []): Promise<InjectedExtension[]> {
   if (!originName) {
     throw new Error('You must pass a name for your app to the web3Enable function');
   }
+
+  compatInits.push(onReefInjectedPromise);
 
   const initCompat = compatInits.length
     ? Promise.all(compatInits.map((c) => c().catch(() => false)))

--- a/packages/extension/src/page.ts
+++ b/packages/extension/src/page.ts
@@ -36,4 +36,6 @@ function inject () {
     name: 'reef',
     version: process.env.PKG_VERSION as string
   });
+  const event = new Event('reef-injected');
+  document.dispatchEvent(event);
 }

--- a/packages/extension/src/page.ts
+++ b/packages/extension/src/page.ts
@@ -37,5 +37,6 @@ function inject () {
     version: process.env.PKG_VERSION as string
   });
   const event = new Event('reef-injected');
+
   document.dispatchEvent(event);
 }


### PR DESCRIPTION
If web3Enable() is called very early extension is not registered for injection yet. 
Here is an example of such case https://github.com/reef-defi/minimal-ui-example/blob/5a7855da7c0ec1d5ef505524207d8b43dbbbefa6/src/extensionUtil.ts#L10
example can be run by 'yarn serve'.