### PR TITLE
fix: define NODE_ENV as "development" in watch config + enable source-maps in development

### DIFF
--- a/packages/extension/webpack.shared.cjs
+++ b/packages/extension/webpack.shared.cjs
@@ -20,7 +20,7 @@ const packages = [
   'extension-ui'
 ];
 
-module.exports = (entry, alias = {}, optimization = {}, output = null) => ({
+module.exports = (entry, alias = {}, optimization = {}, output = null, mode = 'production') => ({
   context: __dirname,
   devtool: false,
   entry,
@@ -76,7 +76,7 @@ module.exports = (entry, alias = {}, optimization = {}, output = null) => ({
     }),
     new webpack.DefinePlugin({
       'process.env': {
-        NODE_ENV: JSON.stringify('production'),
+        NODE_ENV: JSON.stringify(mode),
         PKG_NAME: JSON.stringify(pkgJson.name),
         PKG_VERSION: JSON.stringify(pkgJson.version)
       }

--- a/packages/extension/webpack.shared.cjs
+++ b/packages/extension/webpack.shared.cjs
@@ -22,7 +22,7 @@ const packages = [
 
 module.exports = (entry, alias = {}, optimization = {}, output = null, mode = 'production') => ({
   context: __dirname,
-  devtool: false,
+  devtool: mode === 'production' ? false : 'source-map',
   entry,
   module: {
     rules: [

--- a/packages/extension/webpack.watch.cjs
+++ b/packages/extension/webpack.watch.cjs
@@ -11,5 +11,6 @@ module.exports = createConfig(
     extension: './src/extension.ts',
     page: './src/page.ts'
   },
-  ...chunkingConfigData
+  ...chunkingConfigData,
+  'development'
 );


### PR DESCRIPTION
This solves warning in console upon running `yarn watch`.
Error: WARNING in DefinePlugin. Conflicting values for 'process.env.NODE_ENV'